### PR TITLE
Supports Google search, adds error handling

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,18 +1,25 @@
-let pattern = "https://www.google.com/url?*";
+const pattern = "https://www.google.com/url?*";
 
 function redirect(requestDetails) {
     const srcUrl = requestDetails.url;    
     const srcUrlObj = new URL(srcUrl);
-    const targetUrl = srcUrlObj.searchParams.get("q");
-
-    console.log(`Redirecting: "${srcUrl}" to "${targetUrl}"`);
-    return {
-        redirectUrl: targetUrl
-    };
+    const param = srcUrlObj.searchParams.has("url") ? "url" : "q";
+    const targetUrl = srcUrlObj.searchParams.get(param);
+    
+    try {
+        // ensure URL validity
+        const targetUrlObj = new URL(targetUrl);
+        console.log(`Redirecting: "${srcUrl}" to "${targetUrl}"`);
+        return {
+            redirectUrl: targetUrlObj.toString()
+        };
+    } catch (ex) {
+        console.error(`Failed to detect valid target in "${srcUrl}" using param "${param}"`);
+    }
 }
 
 browser.webRequest.onBeforeRequest.addListener(
-  redirect,
-  { urls: [pattern] },
-  ["blocking"],
+    redirect,
+    { urls: [pattern] },
+    ["blocking"],
 );


### PR DESCRIPTION
In Google search, the target URL is in the query parameter called "url". Prefer that if it's set, otherwise use "q".

Also, only redirect if a valid target URL has been found.